### PR TITLE
update build_backend to be compliant with PEP517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ jupyterlab_widgets = "^3.0.7"
 ipympl = "^0.9.3"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Allow to use only pip install -e . --no-deps in the docker image without changing the poetry build system.
see documentation : [poetry and pep 517](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517)

_(Hello!, I am the freelance software engineer hired by Hector to build you and your team a jupyterlab docker image with all the tools you need for development.)_
